### PR TITLE
Add colyseus into dependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "webpack-dev-server": "^3.1.3"
   },
   "dependencies": {
+    "colyseus": "^0.15.0",
     "express": "^4.16.2",
     "node-os-utils": "^1.2.0",
     "superagent": "^3.8.2"


### PR DESCRIPTION
For anyone who doesn't install colyseus package and just install minimal seperate packages like: @colyseus/core, colyseus/ws-transport, ... It will encounter error:
![image](https://github.com/colyseus/colyseus-monitor/assets/46867018/8db61738-99f3-4d94-8007-0838dfe75374)
File build/api.js required colyseus but in package.json didn't installed it
