### PR TITLE
removed module package.json field that referenced unexisting file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Web Monitoring Panel for Colyseus",
   "input": "./src/index.ts",
   "main": "./build/index.js",
-  "module": "./build/index.mjs",
   "typings": "./build/index.d.ts",
   "scripts": {
     "start": "ts-node example/Server",


### PR DESCRIPTION
Vite is crashing when trying to resolve module field in package.json that points to unexisting ./build/index.mjs file
## in @colyseus/monitor